### PR TITLE
Bump v0.1.3 policy version.

### DIFF
--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.2
+version: 0.1.3
 name: namespace-label-propagator-policy
 displayName: Namespace label propagator
-createdAt: 2023-06-01T19:15:17.442386716Z
+createdAt: 2023-07-07T19:03:20.583059681Z
 description: Kubewarden policy designed to automatically propagate labels defined in a Kubernetes namespace to the associated resources within that namespace
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/namespace-label-propagator-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/namespace-label-propagator:v0.1.2
+  image: ghcr.io/kubewarden/policies/namespace-label-propagator:v0.1.3
 keywords:
 - policy
 - kubewarden
@@ -21,13 +21,13 @@ keywords:
 - label
 links:
 - name: policy
-  url: https://github.com/kubewarden/namespace-label-propagator-policy/releases/download/v0.1.2/policy.wasm
+  url: https://github.com/kubewarden/namespace-label-propagator-policy/releases/download/v0.1.3/policy.wasm
 - name: source
   url: https://github.com/kubewarden/namespace-label-propagator-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/namespace-label-propagator:v0.1.2
+  kwctl pull ghcr.io/kubewarden/policies/namespace-label-propagator:v0.1.3
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
Bump v0.1.3 policy version.        

Updates the Cargo and artifacthub files bumping the policy version to v0.1.3

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
