### PR TITLE
build: remove artifacthub-pkg.yml dependency when annotating a policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ artifacthub-pkg.yml: metadata.yml go.mod
 	  --questions-path questions-ui.yml \
 	  --output artifacthub-pkg.yml
 
-annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
+annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm
 
 .PHONY: test


### PR DESCRIPTION
## Description

Removes artifacthub-pkg.yml dependency, see: https://github.com/kubewarden/go-policy-template/issues/50